### PR TITLE
Downgrade sphinx to 1.6.3 due to problems with sphinx-build.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click==6.6
 Paver==1.2.4
 six==1.10.0
-Sphinx>=1.4.5
+Sphinx==1.6.3
 sphinxcontrib-paverutils>=1.13
 cogapp>=2.5
 SQLAlchemy>=1.0.13


### PR DESCRIPTION
This should be a temporary fix for the problem with sphinx-build.